### PR TITLE
Properly expose the TypeScript types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "browser",
     "tab"
   ],
-  "exports": "./dist/index.js",
+  "exports": {
+    "import": "./dist/index.js",
+    "types": "./index.d.ts"
+  },
   "files": [
     "dist/index.js",
     "*.d.ts"


### PR DESCRIPTION
TypeScript types weren't recognized because they weren't exported by the package. This updates the "types" exports definition to point to the type definition file.